### PR TITLE
Add btusb sco driver support for AX210 TyP2

### DIFF
--- a/include/sound/memalloc.h
+++ b/include/sound/memalloc.h
@@ -16,8 +16,6 @@ struct device;
 struct vm_area_struct;
 struct sg_table;
 
-
-#define snd_dma_continuous_data(x)      ((struct device *)(__force unsigned long)(x))
 /*
  * buffer device info
  */

--- a/sound/usb/btusb/btusb_sco_snd_card.c
+++ b/sound/usb/btusb/btusb_sco_snd_card.c
@@ -102,6 +102,7 @@ static const struct usb_device_id btusb_sco_table[] = {
 	{ USB_DEVICE(0x8087, 0x0aaa), .driver_info = BTUSB_INTEL_NEW },
 	{ USB_DEVICE(0x8087, 0x0aa7), .driver_info = BTUSB_INTEL_NEW },
 	{ USB_DEVICE(0x8087, 0x0033), .driver_info = BTUSB_INTEL_NEW },
+	{ USB_DEVICE(0x8087, 0x0032), .driver_info = BTUSB_INTEL_NEW },
 	{ }	/* Terminating entry */
 };
 
@@ -937,10 +938,8 @@ static int btusb_snd_card_create(struct btusb_data *data)
 					&btusb_isoc_playback_ops);
 	snd_pcm_lib_preallocate_pages_for_all(pcm,
 			SNDRV_DMA_TYPE_CONTINUOUS,
-			dev,
+			NULL,
 			64 * 1024, 64 * 1024);
-//			(void*)snd_dma_continuous_data(GFP_KERNEL),
-//			64 * 1024, 64 * 1024);
 	strlcpy(card->driver, "bt_audio_source", sizeof(card->driver));
 	strlcpy(card->shortname, card->driver, sizeof(card->shortname));
 	strlcpy(card->longname, "USB Bluetooth audio source",


### PR DESCRIPTION
This patch adds btusb sco driver support for Intel Bluetooth AX210 (Typ2).

[Problem]
btusb sco drivers not probed for TyP2 cards, resulting in not creating the btaudiosource sound card, which is required for BT HFP sco call.

[Solution]
Add AX210 vendorid, productid info to the driver table. Now the sound cards are listed with below cmd. As recommended from 6.0+ kernel, the alsa sco driver should pass NULL for continous dma data and snd_dma_continuous_data() is removed.

[Test]
Updated the driver ko file and checked the sound card listing.

Tracked-On: OAM-121421