### PR TITLE
Revert "Fix CtsDeqpTestCases test failures"

### DIFF
--- a/drivers/gpu/drm/i915/i915_pci.c
+++ b/drivers/gpu/drm/i915/i915_pci.c
@@ -649,7 +649,7 @@ static const struct intel_device_info tgl_info = {
 	GEN12_FEATURES,
 	PLATFORM(INTEL_TIGERLAKE),
 	.__runtime.platform_engine_mask =
-		BIT(RCS0) | BIT(BCS0) | BIT(VECS0) | BIT(VCS0) | BIT(VCS2) | BIT(CCS0),
+		BIT(RCS0) | BIT(BCS0) | BIT(VECS0) | BIT(VCS0) | BIT(VCS2),
 	.__runtime.ppgtt_size = 47,
 	.has_sriov = 1,
 };
@@ -677,7 +677,7 @@ static const struct intel_device_info dg1_info = {
 	.require_force_probe = 1,
 	.__runtime.platform_engine_mask =
 		BIT(RCS0) | BIT(BCS0) | BIT(VECS0) |
-		BIT(VCS0) | BIT(VCS2) | BIT(CCS0),
+		BIT(VCS0) | BIT(VCS2),
 	/* Wa_16011227922 */
 	.__runtime.ppgtt_size = 47,
 };
@@ -686,7 +686,7 @@ static const struct intel_device_info adl_s_info = {
 	GEN12_FEATURES,
 	PLATFORM(INTEL_ALDERLAKE_S),
 	.__runtime.platform_engine_mask =
-		BIT(RCS0) | BIT(BCS0) | BIT(VECS0) | BIT(VCS0) | BIT(VCS2) | BIT(CCS0),
+		BIT(RCS0) | BIT(BCS0) | BIT(VECS0) | BIT(VCS0) | BIT(VCS2),
 	.__runtime.ppgtt_size = 47,
 	.dma_mask_size = 39,
 	.has_sriov = 1,
@@ -696,7 +696,7 @@ static const struct intel_device_info adl_p_info = {
 	GEN12_FEATURES,
 	PLATFORM(INTEL_ALDERLAKE_P),
 	.__runtime.platform_engine_mask =
-		BIT(RCS0) | BIT(BCS0) | BIT(VECS0) | BIT(VCS0) | BIT(VCS2) | BIT(CCS0),
+		BIT(RCS0) | BIT(BCS0) | BIT(VECS0) | BIT(VCS0) | BIT(VCS2),
 	.__runtime.ppgtt_size = 47,
 	.dma_mask_size = 39,
 	.has_sriov = 1,


### PR DESCRIPTION
This reverts commit de9fa46242e46d1bd93459fa14ef05259a7aed1e as it is causing boot issue in SRIOV mode.

Tests done:
- caas boot in GVT-d and SRIOV mode
- aaos boot in GVT-d and SRIOV mode
- Wi-Fi, Bluetooth on/off/connect/disconnect
- adb root
- adb remount

Tracked-On: