### PR TITLE
Virtio spi controller driver

### DIFF
--- a/drivers/spi/Kconfig
+++ b/drivers/spi/Kconfig
@@ -1049,6 +1049,17 @@ config SPI_UNIPHIER
 
 	  If your SoC supports SCSSI, say Y here.
 
+config SPI_VIRTIO
+	tristate "Virtio SPI Controller"
+	select VIRTIO
+	help
+	  This enableds virtio SPI controller driver support. The hardware can
+	  be emulated by any device model software according to the virtio
+	  protocol.
+
+	  This driver can also be built as a module. If so, the module
+	  will be called spi-virtio.
+
 config SPI_XCOMM
 	tristate "Analog Devices AD-FMCOMMS1-EBZ SPI-I2C-bridge driver"
 	depends on I2C

--- a/drivers/spi/Makefile
+++ b/drivers/spi/Makefile
@@ -138,6 +138,7 @@ spi-thunderx-objs			:= spi-cavium.o spi-cavium-thunderx.o
 obj-$(CONFIG_SPI_THUNDERX)		+= spi-thunderx.o
 obj-$(CONFIG_SPI_TOPCLIFF_PCH)		+= spi-topcliff-pch.o
 obj-$(CONFIG_SPI_UNIPHIER)		+= spi-uniphier.o
+obj-$(CONFIG_SPI_VIRTIO) 		+= spi-virtio.o
 obj-$(CONFIG_SPI_XCOMM)		+= spi-xcomm.o
 obj-$(CONFIG_SPI_XILINX)		+= spi-xilinx.o
 obj-$(CONFIG_SPI_XLP)			+= spi-xlp.o

--- a/drivers/spi/spi-virtio.c
+++ b/drivers/spi/spi-virtio.c
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Virtio SPI Controller Driver
+ *
+ * The Virtio SPI Specification Patch this driver follows:
+ * https://lore.kernel.org/all/20230901032933.32434-1-quic_haixcui@quicinc.com/
+ * With some fixes in comments. bus_num is removed from config since it's
+ * unnecessary.
+ *
+ * Copyright (c) 2023 Intel Corporation. All rights reserved.
+ */
+
+#include <linux/acpi.h>
+#include <linux/completion.h>
+#include <linux/err.h>
+#include <linux/spi/spi.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/virtio.h>
+#include <linux/virtio_ids.h>
+#include <linux/virtio_config.h>
+#include <linux/virtio_spi.h>
+
+#define VIRTIO_MAX_XFER_SIZE		0xffffff
+
+/**
+ * struct virtio_spi - virtio SPI data
+ * @vdev: virtio device for this controller
+ * @master: spi master for the spi core
+ * @vq: the virtio virtqueue for communication
+ */
+struct virtio_spi {
+	struct virtio_device *vdev;
+	struct spi_master *master;
+	struct virtqueue *vq;
+};
+
+/**
+ * struct virtio_spi_req - the virtio SPI request structure
+ * @completion: completion of virtio SPI message
+ * @head: the transfer header of the virtio SPI message
+ * @tx_buf: the buffer from which it's written
+ * @rx_buf: the buffer into which data is read
+ * @result: the result of the virtio I2C message
+ */
+struct virtio_spi_req {
+	struct completion completion;
+	struct virtio_spi_transfer_head head;
+	const void *tx_buf;
+	void *rx_buf;
+	struct virtio_spi_transfer_result result;
+};
+};
+
+static void virtio_spi_xfer_done(struct virtqueue *vq)
+{
+	struct virtio_spi_req *req;
+	unsigned int len;
+
+	while ((req = virtqueue_get_buf(vq, &len)))
+		complete(&req->completion);
+}
+
+static void virtio_spi_del_vqs(struct virtio_device *vdev)
+{
+	vdev->config->reset(vdev);
+	vdev->config->del_vqs(vdev);
+}
+
+static int virtio_spi_setup_vqs(struct virtio_spi *vspi)
+{
+	struct virtio_device *vdev = vspi->vdev;
+
+	vspi->vq = virtio_find_single_vq(vdev, virtio_spi_xfer_done, "xfer");
+	return PTR_ERR_OR_ZERO(vspi->vq);
+}
+
+static size_t virtio_spi_max_transfer_size(struct spi_device *spi)
+{
+	return VIRTIO_MAX_XFER_SIZE;
+}
+
+static int virtio_spi_transfer_one(struct spi_master *master,
+				  struct spi_device *spi,
+				  struct spi_transfer *xfer)
+{
+	struct virtio_spi *vspi = spi_master_get_devdata(master);
+	struct virtio_spi_req *req;
+	struct scatterlist *sgs[4], head, tx_buf, rx_buf, res;
+	int ret = 0;
+
+	req = kzalloc(sizeof(*req), GFP_KERNEL);
+	if (!req)
+		return -ENOMEM;
+
+	init_completion(&req->completion);
+	req->head.slave_id = spi->chip_select;
+	req->head.bits_per_word = spi->bits_per_word;
+	req->head.cs_change = xfer->cs_change;
+	req->head.tx_nbits = xfer->tx_nbits;
+	req->head.rx_nbits = xfer->rx_nbits;
+	req->head.mode = spi->mode;
+	req->head.freq = xfer->speed_hz;
+	req->head.word_delay_ns = spi_delay_to_ns(&xfer->word_delay, xfer);
+	req->head.cs_setup_ns = spi_delay_to_ns(&spi->cs_setup, xfer);
+	req->head.cs_delay_hold_ns = spi_delay_to_ns(&spi->cs_hold, xfer);
+	req->head.cs_change_delay_inactive_ns = spi_delay_to_ns(&spi->cs_inactive, xfer) + spi_delay_to_ns(&xfer->cs_change_delay, xfer);
+	sg_init_one(&head, &req->head, sizeof(req->head));
+	sgs[0] = &head;
+
+	req->tx_buf = xfer->tx_buf;
+	sg_init_one(&tx_buf, req->tx_buf, xfer->len);
+	sgs[1] = &tx_buf;
+	req->rx_buf = xfer->rx_buf;
+	sg_init_one(&rx_buf, req->rx_buf, xfer->len);
+	sgs[2] = &rx_buf;
+
+	sg_init_one(&res, &req->result, sizeof(req->result));
+	sgs[3] = &res;
+
+	ret = virtqueue_add_sgs(vspi->vq, sgs, 2, 2, req, GFP_KERNEL);
+	if (ret) {
+		dev_err(&vspi->vdev->dev, "fail to add sgs to vq!\n");
+		goto err_free;
+	}
+
+	virtqueue_kick(vspi->vq);
+
+	wait_for_completion(&req->completion);
+
+	if (req->result.result != VIRTIO_SPI_TRANS_OK) {
+		dev_err(&vspi->vdev->dev, "result is bad!\n");
+		ret = -EIO;
+	}
+
+err_free:
+	kfree(req);
+	return ret;
+}
+
+static int virtio_spi_probe(struct virtio_device *vdev)
+{
+	struct virtio_spi *vspi;
+	struct spi_master *master;
+	int ret = 0;
+
+	master = spi_alloc_master(&vdev->dev, sizeof(struct virtio_spi));
+	if (!master) {
+		dev_err(&vdev->dev, "Unable to allocate SPI Master\n");
+		return -ENOMEM;
+	}
+	vspi = spi_master_get_devdata(master);
+	vdev->priv = vspi;
+	vspi->vdev = vdev;
+	vspi->master = master;
+
+	ret = virtio_spi_setup_vqs(vspi);
+	if (ret)
+		goto err_free_master;
+
+	master->transfer_one = virtio_spi_transfer_one;
+	master->num_chipselect = virtio_cread16(vdev,
+			offsetof(struct virtio_spi_config, num_cs));
+	master->mode_bits = SPI_CPOL | SPI_CPHA | SPI_CS_HIGH | SPI_LSB_FIRST;
+	master->bits_per_word_mask = SPI_BPW_MASK(8);
+	master->max_transfer_size = virtio_spi_max_transfer_size;
+
+	/*
+	 * Setup ACPI node for controlled devices which will be probed through
+	 * ACPI.
+	 */
+	ACPI_COMPANION_SET(&vdev->dev, ACPI_COMPANION(vdev->dev.parent));
+
+	ret = devm_spi_register_master(&vdev->dev, master);
+	if (ret) {
+		dev_err(&vdev->dev, "cannot register SPI master\n");
+		goto err_del_vqs;
+	}
+
+	return 0;
+
+err_del_vqs:
+	virtio_spi_del_vqs(vdev);
+err_free_master:
+	spi_master_put(master);
+	return ret;
+}
+
+static void virtio_spi_remove(struct virtio_device *vdev)
+{
+	struct virtio_spi *vspi = vdev->priv;
+
+	virtio_spi_del_vqs(vdev);
+	spi_master_put(vspi->master);
+}
+
+static struct virtio_device_id id_table[] = {
+	{ VIRTIO_ID_SPI, VIRTIO_DEV_ANY_ID },
+	{}
+};
+
+#ifdef CONFIG_PM_SLEEP
+static int virtio_spi_freeze(struct virtio_device *vdev)
+{
+	virtio_spi_del_vqs(vdev);
+	return 0;
+}
+
+static int virtio_spi_restore(struct virtio_device *vdev)
+{
+	return virtio_spi_setup_vqs(vdev->priv);
+}
+#endif
+
+static struct virtio_driver virtio_spi_driver = {
+	.id_table		= id_table,
+	.probe			= virtio_spi_probe,
+	.remove			= virtio_spi_remove,
+	.driver			= {
+		.name	= "virtio-spi",
+	},
+#ifdef CONFIG_PM_SLEEP
+	.freeze = virtio_spi_freeze,
+	.restore = virtio_spi_restore,
+#endif
+};
+module_virtio_driver(virtio_spi_driver);
+
+MODULE_AUTHOR("Qiang Zhang <qiang4.zhang@intel.com>");
+MODULE_DESCRIPTION("Virtio SPI controller driver");
+MODULE_LICENSE("GPL");

--- a/include/uapi/linux/virtio_ids.h
+++ b/include/uapi/linux/virtio_ids.h
@@ -69,6 +69,7 @@
 #define VIRTIO_ID_AUDIO_POLICY		39 /* virtio audio policy */
 #define VIRTIO_ID_BT			40 /* virtio bluetooth */
 #define VIRTIO_ID_GPIO			41 /* virtio gpio */
+#define VIRTIO_ID_SPI			45 /* virtio spi */
 
 /*
  * Virtio Transitional IDs

--- a/include/uapi/linux/virtio_spi.h
+++ b/include/uapi/linux/virtio_spi.h
@@ -1,0 +1,63 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later WITH Linux-syscall-note */
+/*
+ * Definitions for virtio SPI Controller
+ *
+ * Copyright (c) 2023 Intel Corporation. All rights reserved.
+ */
+
+#ifndef _UAPI_LINUX_VIRTIO_SPI_H
+#define _UAPI_LINUX_VIRTIO_SPI_H
+
+#include <linux/const.h>
+#include <linux/types.h>
+
+/* Virtio SPI Feature bits */
+
+struct virtio_spi_config {
+	/* maximum number of chip selects */
+	__le16 num_cs;
+} __attribute__((packed));
+
+/**
+ * struct virtio_spi_transfer_head - the virtio SPI transfer parameter header
+ * @slave_id: the controlled slave chip select
+ * @bits_per_word: the number of bits in each SPI transfer word
+ * @cs_change: whether to deselect device before starting the next transfer
+ * @tx_nbits: bus width for write transfer
+ * @rx_nbits: bus width for read transfer
+ * @paddings: used to pad to full dword
+ * @mode: how data is clocked out and in
+ * @freq: the SPI transfer speed in Hz
+ * @word_delay_ns: delay between consecutive words of a transfer
+ * @cs_setup_ns: delay after chipselect is asserted
+ * @cs_delay_hold_ns: delay before chipselect is deasserted
+ * @cs_change_delay_inactive_ns: delay between chipselect deassertion and next assertion
+ */
+struct virtio_spi_transfer_head {
+	__u8 slave_id;
+	__u8 bits_per_word;
+	__u8 cs_change;
+	__u8 tx_nbits;
+	__u8 rx_nbits;
+	__u8 paddings[3];
+	__le32 mode;
+	__le32 freq;
+	__le32 word_delay_ns;
+	__le32 cs_setup_ns;
+	__le32 cs_delay_hold_ns;
+	__le32 cs_change_delay_inactive_ns;
+};
+
+/**
+ * struct virtio_spi_transfer_result - the virtio SPI transfer reuslt
+ * @result: the processing result from the backend
+ */
+struct virtio_spi_transfer_result {
+	__u8 result;
+};
+
+/* The final status written by the device */
+#define VIRTIO_SPI_TRANS_OK	0
+#define VIRTIO_SPI_TRANS_ERR	1
+
+#endif /* _UAPI_LINUX_VIRTIO_SPI_H */

--- a/include/uapi/linux/virtio_spi.h
+++ b/include/uapi/linux/virtio_spi.h
@@ -60,4 +60,24 @@ struct virtio_spi_transfer_result {
 #define VIRTIO_SPI_TRANS_OK	0
 #define VIRTIO_SPI_TRANS_ERR	1
 
+/**
+ * struct virtio_spi_event_head - the virtio SPI event unmask request header
+ * @slave_id: the controlled slave chip select
+ */
+struct virtio_spi_event_head {
+	__u8 slave_id;
+};
+
+/**
+ * struct virtio_spi_event_result - the virtio SPI event reuslt
+ * @result: the irq event result from the backend
+ */
+struct virtio_spi_event_result {
+	__u8 result;
+};
+
+/* The irq event status for the device */
+#define VIRTIO_SPI_IRQ_VALID	0
+#define VIRTIO_SPI_IRQ_INVALID	1
+
 #endif /* _UAPI_LINUX_VIRTIO_SPI_H */


### PR DESCRIPTION
Test done:

Boot up Android as a guest of ACRN with one Virtio SPI device.
- Run ls -l /sys/class/spi_master/ to find the Virtio SPI controller and
  underlying SPI devices
- Run spidev_test to transfer data with test loopback SPI device.

Tracked-On: OAM-122209