### PR TITLE
[VTS FIX] Wifi: iwlmvm: enable vendor-cmd for vts test

### DIFF
--- a/drivers/net/wireless/intel/iwlwifi/mvm/Makefile
+++ b/drivers/net/wireless/intel/iwlwifi/mvm/Makefile
@@ -10,6 +10,6 @@ iwlmvm-y += rfi.o
 iwlmvm-$(CONFIG_IWLWIFI_DEBUGFS) += debugfs.o debugfs-vif.o
 iwlmvm-$(CONFIG_IWLWIFI_LEDS) += led.o
 iwlmvm-$(CONFIG_PM) += d3.o
-iwlmvm-$(CONFIG_IWLMEI) += vendor-cmd.o
+iwlmvm-y += vendor-cmd.o
 
 ccflags-y += -I $(srctree)/$(src)/../

--- a/drivers/net/wireless/intel/iwlwifi/mvm/mvm.h
+++ b/drivers/net/wireless/intel/iwlwifi/mvm/mvm.h
@@ -1951,16 +1951,8 @@ void iwl_mvm_enter_ctkill(struct iwl_mvm *mvm);
 int iwl_mvm_send_temp_report_ths_cmd(struct iwl_mvm *mvm);
 int iwl_mvm_ctdp_command(struct iwl_mvm *mvm, u32 op, u32 budget);
 
-#if IS_ENABLED(CONFIG_IWLMEI)
-
 /* vendor commands */
 void iwl_mvm_vendor_cmds_register(struct iwl_mvm *mvm);
-
-#else
-
-static inline void iwl_mvm_vendor_cmds_register(struct iwl_mvm *mvm) {}
-
-#endif
 
 /* Location Aware Regulatory */
 struct iwl_mcc_update_resp *

--- a/drivers/net/wireless/intel/iwlwifi/mvm/vendor-cmd.c
+++ b/drivers/net/wireless/intel/iwlwifi/mvm/vendor-cmd.c
@@ -5,6 +5,7 @@
 #include "mvm.h"
 #include <linux/nl80211-vnd-intel.h>
 #include <net/netlink.h>
+#include <linux/utsname.h>
 
 static const struct nla_policy
 iwl_mvm_vendor_attr_policy[NUM_IWL_MVM_VENDOR_ATTR] = {


### PR DESCRIPTION
VtsHalWifiChipTargetTest is failing as the vendor
command requests are failing.

Vendor command file is compiled based on CONFIG_IWLMEI.
As CONFIG_IWLMEI is not enabled, vendor command is not
compiled at all.

Fix the issue by unconditionally compiling the vendor
command file.

Test:
VtsHalWifiChipTargetTest can pass

Tracked-On: OAM-122539
Change-Id: Ic345a75ef08ff07dd96164fe8d13011208b57a2a