### PR TITLE
fix build error in function mddev_destroy_serial_pool

### DIFF
--- a/drivers/md/md.c
+++ b/drivers/md/md.c
@@ -2508,7 +2508,7 @@ static int bind_rdev_to_array(struct md_rdev *rdev, struct mddev *mddev)
  fail:
 	pr_warn("md: failed to register dev-%s for %s\n",
 		b, mdname(mddev));
-	mddev_destroy_serial_pool(mddev, rdev);
+	mddev_destroy_serial_pool(mddev, rdev, false);
 	return err;
 }
 


### PR DESCRIPTION
Merge of "md: fix kmemleak of rdev->serial" patch causes too few arguments to function ‘mddev_destroy_serial_pool’ build error.

Fix the issue by calling mddev_destroy_serial_pool with correct arguments.

Tests done:
- Host kernel build

Tracked-On: OAM-123076