### PR TITLE
drm/virtio: fixed vblank issue for multi monitor

### DIFF
--- a/drivers/gpu/drm/virtio/virtgpu_drv.h
+++ b/drivers/gpu/drm/virtio/virtgpu_drv.h
@@ -279,7 +279,7 @@ struct virtio_gpu_device {
 	spinlock_t resource_export_lock;
 	/* protects map state and host_visible_mm */
 	spinlock_t host_visible_lock;
-	struct virtio_gpu_vblank vblank[];
+	struct virtio_gpu_vblank vblank[VIRTIO_GPU_MAX_SCANOUTS];
 };
 
 struct virtio_gpu_fpriv {

--- a/drivers/gpu/drm/virtio/virtgpu_vq.c
+++ b/drivers/gpu/drm/virtio/virtgpu_vq.c
@@ -83,6 +83,10 @@ void virtio_gpu_vblank_poll_arm(struct virtqueue *vq)
 	while((target < vgdev->num_vblankq) && (vgdev->vblank[target].vblank.vq != vq)) {
 		target++;
 	}
+	if (target >= vgdev->num_vblankq) {
+		DRM_WARN("virtio-gpu, received invalid vblank\n");
+		return;
+	}
 
 	spin_lock_irqsave(&vgdev->vblank[target].vblank.qlock, irqflags);
 	if((ret_value = virtqueue_get_buf(vq, &len)) != NULL) {


### PR DESCRIPTION
this fix is for below kernel warning "virtio-pci 0000: 00:04.0: drm_WARN_ON(pipe >= dev->num_crtcs)"

Tracked-On: OAM-123669