### PR TITLE
[FOR DEBUG] drm/virtio: avoid to take long time to receive vblank event

### DIFF
--- a/drivers/gpu/drm/virtio/virtgpu_vq.c
+++ b/drivers/gpu/drm/virtio/virtgpu_vq.c
@@ -111,6 +111,7 @@ void virtio_gpu_vblank_ack(struct virtqueue *vq)
 
 		virtgpu_irqqueue_buf(vgdev->vblank[target].vblank.vq, ret_value);
 	}
+	virtqueue_kick(vq);
 
 	spin_unlock_irqrestore(&vgdev->vblank[target].vblank.qlock, irqflags);
 	drm_handle_vblank(dev, target);


### PR DESCRIPTION
virtio gpu fe kick vq after reveice irq, then virtio gpu backend could send vblank event as soon as possible.

Test-done:
    - igpu + virtio gpu

Tracked-On: OAM-123669