### PR TITLE
Mofify for ivshmem

### DIFF
--- a/drivers/virtio/virtio_shmem.c
+++ b/drivers/virtio/virtio_shmem.c
@@ -616,6 +616,14 @@ static dma_addr_t page_to_dma_addr(struct virtio_shmem_device *vi_dev, struct pa
 	return dma_handle;
 }
 
+dma_addr_t virtio_shmem_page_to_dma_addr(struct device *dev, struct page *page)
+{
+	struct pci_dev *pci_dev = to_pci_dev(dev);
+	struct virtio_shmem_device *vi_dev = pci_get_drvdata(pci_dev);
+
+	return page_to_dma_addr(vi_dev, page);
+}
+
 static void *vi_dma_alloc(struct device *dev, size_t size,
 			  dma_addr_t *dma_handle, gfp_t flag,
 			  unsigned long attrs)

--- a/include/linux/virtio_shm.h
+++ b/include/linux/virtio_shm.h
@@ -10,6 +10,7 @@
 #ifdef CONFIG_VIRTIO_IVSHMEM
 struct page *virtio_shmem_allocate_page(struct device *dev);
 void virtio_shmem_free_page(struct device *dev, struct page *page);
+dma_addr_t virtio_shmem_page_to_dma_addr(struct device *dev, struct page *page);
 #else
 static inline struct page *virtio_shmem_allocate_page(struct device *dev)
 {


### PR DESCRIPTION
This patch add a function to map the gpa to ivshmem offset.

Test done:
1. QNX + virtio camera + IPU Camera
2. QNX + virtio camera + UVC Camera

Tracked-On: OAM-124423