### PR TITLE
virtio gpu: add import dmabuf check

### DIFF
--- a/drivers/gpu/drm/virtio/virtgpu_kms.c
+++ b/drivers/gpu/drm/virtio/virtgpu_kms.c
@@ -282,6 +282,12 @@ int virtio_gpu_init(struct virtio_device *vdev, struct drm_device *dev)
 		 vgdev->has_resource_blob ? '+' : '-',
 		 vgdev->has_host_visible ? '+' : '-');
 
+	DRM_INFO("features: %cscaling %cvblank %cmodifier %cmulti_plane",
+		 vgdev->has_scaling ? '+' : '-',
+		 vgdev->has_vblank ? '+' : '-',
+		 vgdev->has_modifier ? '+' : '-',
+		 vgdev->has_multi_plane ? '+' : '-');
+
 	DRM_INFO("features: %ccontext_init\n",
 		 vgdev->has_context_init ? '+' : '-');
 

--- a/drivers/gpu/drm/virtio/virtgpu_prime.c
+++ b/drivers/gpu/drm/virtio/virtgpu_prime.c
@@ -164,6 +164,10 @@ struct drm_gem_object *virtgpu_gem_prime_import(struct drm_device *dev,
 		}
 	}
 
+	if (strcmp(dev->dev->driver->name, "virtio-ivshmem") == 0 ||
+			strcmp(dev->dev->driver->name, "virtio-guest-shm") == 0)
+		return ERR_PTR(-EINVAL);
+
 	if (!dev->driver->gem_prime_import_sg_table)
 		return ERR_PTR(-EINVAL);
 	attach = ____dma_buf_dynamic_attach(dma_buf, attach_dev, NULL, NULL,


### PR DESCRIPTION
if virtio gpu is working on top of ivshmem
then do not accept buffer allocated by i915 to
import, since it can not be displayed.

Tracked-On: OAM-124035