### PR TITLE
drm/virtio: Change value of feature ALLOW_P2P to 13

### DIFF
--- a/include/uapi/linux/virtio_gpu.h
+++ b/include/uapi/linux/virtio_gpu.h
@@ -75,7 +75,7 @@
 
 #define VIRTIO_GPU_F_VBLANK              7
 
-#define VIRTIO_GPU_F_ALLOW_P2P           31
+#define VIRTIO_GPU_F_ALLOW_P2P           13
 
 /*
  * VIRTIO_GPU_CMD_FLUSH_SPRITE


### PR DESCRIPTION
Original value 31 is reserved for extensions to the queue and feature negotiation mechanisms by virtio spec (Chapter 2, Section 2.2). To avoid violation to the spec, change the value to 13, which is within the range for specific virtio device type.

Test-done:
- Boot AAOS with dGPU SR-IOV VF and virtio-GPU backed by dGPU display.

Tracked-On: OAM-124694