### PR TITLE
drm/virtio: set max vblank number

### DIFF
--- a/drivers/gpu/drm/virtio/virtgpu_drv.h
+++ b/drivers/gpu/drm/virtio/virtgpu_drv.h
@@ -292,7 +292,7 @@ struct virtio_gpu_device {
 	spinlock_t resource_export_lock;
 	/* protects map state and host_visible_mm */
 	spinlock_t host_visible_lock;
-	struct virtio_gpu_vblank vblank[];
+	struct virtio_gpu_vblank vblank[VIRTIO_GPU_MAX_SCANOUTS];
 };
 
 struct virtio_gpu_fpriv {


### PR DESCRIPTION
vblank array in virtio gpu struct is zero array, and driver does not allocate buffer for it, so set max vblank number and check it.

Tracked-On: OAM-126006