### PR TITLE
drm/virtio: put set modifier ahead of set scanout

### DIFF
--- a/drivers/gpu/drm/virtio/virtgpu_drv.h
+++ b/drivers/gpu/drm/virtio/virtgpu_drv.h
@@ -480,6 +480,7 @@ virtio_gpu_cmd_set_scanout_blob(struct virtio_gpu_device *vgdev,
 				uint32_t x, uint32_t y);
 void virtio_gpu_cmd_set_modifier(struct virtio_gpu_device *vgdev,
 				 uint32_t scanout_id,
+				 struct virtio_gpu_object *bo,
 				 struct drm_framebuffer *fb);
 
 void virtio_gpu_cmd_set_scaling(struct virtio_gpu_device *vgdev,

--- a/drivers/gpu/drm/virtio/virtgpu_plane.c
+++ b/drivers/gpu/drm/virtio/virtgpu_plane.c
@@ -520,6 +520,8 @@ static void virtio_gpu_primary_plane_update(struct drm_plane *plane,
 			  plane->state->src_y >> 16);
 
 		if (bo->host3d_blob || bo->guest_blob) {
+			if (vgdev->has_modifier)
+				virtio_gpu_cmd_set_modifier(vgdev, output->index, bo, plane->state->fb);
 			virtio_gpu_cmd_set_scanout_blob
 						(vgdev, output->index, bo,
 						 plane->state->fb,
@@ -527,8 +529,6 @@ static void virtio_gpu_primary_plane_update(struct drm_plane *plane,
 						 plane->state->src_h >> 16,
 						 plane->state->src_x >> 16,
 						 plane->state->src_y >> 16);
-			if (vgdev->has_modifier)
-				virtio_gpu_cmd_set_modifier(vgdev, output->index, plane->state->fb);
 
 		} else {
 			virtio_gpu_cmd_set_scanout(vgdev, output->index,

--- a/drivers/gpu/drm/virtio/virtgpu_vq.c
+++ b/drivers/gpu/drm/virtio/virtgpu_vq.c
@@ -1549,6 +1549,7 @@ void virtio_gpu_cmd_set_scanout_blob(struct virtio_gpu_device *vgdev,
 
 void virtio_gpu_cmd_set_modifier(struct virtio_gpu_device *vgdev,
 				     uint32_t scanout_id,
+				     struct virtio_gpu_object *bo,
 				     struct drm_framebuffer *fb)
 {
 	struct virtio_gpu_set_modifier *cmd_p;
@@ -1559,6 +1560,7 @@ void virtio_gpu_cmd_set_modifier(struct virtio_gpu_device *vgdev,
 	cmd_p->hdr.type = cpu_to_le32(VIRTIO_GPU_CMD_SET_MODIFIER);
 	cmd_p->modifier = cpu_to_le64(fb->modifier);
 	cmd_p->scanout_id = cpu_to_le32(scanout_id);
+	cmd_p->resource_id = cpu_to_le32(bo->hw_res_handle);
 	virtio_gpu_queue_ctrl_buffer(vgdev, vbuf);
 }
 

--- a/include/uapi/linux/virtio_gpu.h
+++ b/include/uapi/linux/virtio_gpu.h
@@ -556,7 +556,7 @@ struct virtio_gpu_set_modifier {
 	struct virtio_gpu_ctrl_hdr hdr;
 	__le64 modifier;
 	__le32 scanout_id;
-	__le32 padding;
+	__le32 resource_id;
 };
 
 /* VIRTIO_GPU_CMD_RESOURCE_MAP_BLOB */


### PR DESCRIPTION
put set modifier ahead of set scanout to avoid set scaout operation can not get the lastest modifier, and refine set modifer api to pass resource id to backend.

Tests Done:
1, virito-gpu + iGPU

Tracked-On: OAM-123901