### PR TITLE
Disable Broadcom and Realtech Bluetooth config

### DIFF
--- a/drivers/bluetooth/Kconfig
+++ b/drivers/bluetooth/Kconfig
@@ -49,7 +49,7 @@ config BT_HCIBTUSB_BCM
 	bool "Broadcom protocol support"
 	depends on BT_HCIBTUSB
 	select BT_BCM
-	default y
+	default n
 	help
 	  The Broadcom protocol support enables firmware and patchram
 	  download support for Broadcom Bluetooth controllers.
@@ -72,7 +72,7 @@ config BT_HCIBTUSB_RTL
 	bool "Realtek protocol support"
 	depends on BT_HCIBTUSB
 	select BT_RTL
-	default y
+	default n
 	help
 	  The Realtek protocol support enables firmware and configuration
 	  download support for Realtek Bluetooth controllers.


### PR DESCRIPTION
Disable Broadcom and Realtech Bluetooth config,
to reduce Bluetooth driver init time.

Tests:
Bluetooth can boot up success and init time less

Tracked-On: OAM-127329