### PR TITLE
Add userptr flag for vb2

### DIFF
--- a/drivers/media/platform/virtio/virtio-camera.c
+++ b/drivers/media/platform/virtio/virtio-camera.c
@@ -961,7 +961,7 @@ static int virtio_camera_setup_vnode(struct virtio_device *vdev,
 			vnode->vb_queue.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
 			vnode->vb_queue.buf_struct_size = sizeof(struct virtio_camera_buffer);
 			vnode->vb_queue.timestamp_flags = V4L2_BUF_FLAG_TIMESTAMP_MONOTONIC;
-			vnode->vb_queue.io_modes = VB2_MMAP | VB2_DMABUF;
+			vnode->vb_queue.io_modes = VB2_MMAP | VB2_DMABUF | VB2_USERPTR;;
 			vnode->vb_queue.mem_ops = &vb2_dma_sg_memops;
 			vnode->vb_queue.lock = &vnode->video_lock;
 			vnode->vb_queue.min_buffers_needed = 1;


### PR DESCRIPTION
The current code have only config VB2_MMAP and VB2_DMABUF flag for queue access methods.

Now we need alloc memory in the userspace and q/dq these buffers to vb2, so, this patch add the VB2_USERPTR flag.

Tracked-On: OAM-128123