### PR TITLE
drm/virtio: Save address entries of PRIME objects

### DIFF
--- a/drivers/gpu/drm/virtio/virtgpu_debugfs.c
+++ b/drivers/gpu/drm/virtio/virtgpu_debugfs.c
@@ -101,10 +101,30 @@ virtio_gpu_debugfs_host_visible_mm(struct seq_file *m, void *data)
 	return 0;
 }
 
+static int
+virtio_gpu_debugfs_objects(struct seq_file *m, void *data)
+{
+	struct drm_info_node *node = (struct drm_info_node *)m->private;
+	struct virtio_gpu_device *vgdev = node->minor->dev->dev_private;
+	struct virtio_gpu_object_restore *curr, *tmp;
+
+	list_for_each_entry_safe(curr, tmp, &vgdev->obj_rec, node) {
+		seq_printf(m, "hw_res_handle=%u, prime=%d\n",
+			   curr->bo->hw_res_handle, curr->bo->prime);
+		if (curr->bo->prime)
+			for (unsigned i = 0; i < curr->bo->nents; ++i)
+				seq_printf(m, "\taddr=%lx, size=%x\n",
+					   curr->bo->ents[i].addr,
+					   curr->bo->ents[i].length);
+	}
+	return 0;
+}
+
 static struct drm_info_list virtio_gpu_debugfs_list[] = {
 	{ "virtio-gpu-features", virtio_gpu_features },
 	{ "virtio-gpu-irq-fence", virtio_gpu_debugfs_irq_info, 0, NULL },
 	{ "virtio-gpu-host-visible-mm", virtio_gpu_debugfs_host_visible_mm },
+	{ "virtio-gpu-objects", virtio_gpu_debugfs_objects },
 };
 
 #define VIRTIO_GPU_DEBUGFS_ENTRIES ARRAY_SIZE(virtio_gpu_debugfs_list)

--- a/drivers/gpu/drm/virtio/virtgpu_drv.h
+++ b/drivers/gpu/drm/virtio/virtgpu_drv.h
@@ -90,12 +90,16 @@ struct virtio_gpu_object {
 	struct drm_gem_shmem_object base;
 	uint32_t hw_res_handle;
 	bool dumb;
+	bool prime;
 	bool created;
 	bool host3d_blob, guest_blob;
 	uint32_t blob_mem, blob_flags;
 
 	int uuid_state;
 	uuid_t uuid;
+	/* Address cache for prime object */
+	struct virtio_gpu_mem_entry *ents;
+	uint32_t nents;
 };
 #define gem_to_virtio_gpu_obj(gobj) \
 	container_of((gobj), struct virtio_gpu_object, base.base)

--- a/drivers/gpu/drm/virtio/virtgpu_object.c
+++ b/drivers/gpu/drm/virtio/virtgpu_object.c
@@ -113,6 +113,10 @@ void virtio_gpu_cleanup_object(struct virtio_gpu_object *bo)
 		drm_gem_object_release(&vram->base.base.base);
 		kfree(vram);
 	}
+
+	if (bo->prime)
+		kfree(bo->ents);
+
 	virtio_gpu_object_del_restore_list(vgdev, bo);
 }
 
@@ -292,9 +296,16 @@ int virtio_gpu_object_restore_all(struct virtio_gpu_device *vgdev)
 	int ret = 0;
 
 	list_for_each_entry_safe(curr, tmp, &vgdev->obj_rec, node) {
-		ret = virtio_gpu_object_shmem_init(vgdev, curr->bo, &ents, &nents);
-		if (ret)
-			break;
+		if (curr->bo->prime) {
+			nents = curr->bo->nents;
+			ents = kmemdup(curr->bo->ents,
+				       nents * sizeof(struct virtio_gpu_mem_entry),
+				       GFP_KERNEL);
+		} else {
+			ret = virtio_gpu_object_shmem_init(vgdev, curr->bo, &ents, &nents);
+			if (ret)
+				break;
+		}
 
 		if (curr->params.blob) {
 			virtio_gpu_cmd_resource_create_blob(vgdev, curr->bo, &curr->params,


### PR DESCRIPTION
For PRIME objects we need to cache the addresses and use them to re-create resources upon resuming.