### PR TITLE
add support for VF LMEM type BLOB creation

### DIFF
--- a/drivers/gpu/drm/virtio/virtgpu_drv.h
+++ b/drivers/gpu/drm/virtio/virtgpu_drv.h
@@ -97,6 +97,8 @@ struct virtio_gpu_object {
 
 	int uuid_state;
 	uuid_t uuid;
+	/* indicating the obj in lmem or system memory */
+	int locate;
 	/* Address cache for prime object */
 	struct virtio_gpu_mem_entry *ents;
 	uint32_t nents;
@@ -254,6 +256,8 @@ struct virtio_gpu_device {
 	atomic64_t flip_sequence[VIRTIO_GPU_MAX_SCANOUTS];
 	uint32_t num_scanouts;
 	uint32_t num_vblankq;
+	/* Setting '1' indicates the spcecific scanout is for dgpu output*/
+	uint32_t output_cap_mask;
 	struct virtio_gpu_queue ctrlq;
 	struct virtio_gpu_queue cursorq;
 

--- a/drivers/gpu/drm/virtio/virtgpu_ioctl.c
+++ b/drivers/gpu/drm/virtio/virtgpu_ioctl.c
@@ -112,6 +112,7 @@ static int virtio_gpu_getparam_ioctl(struct drm_device *dev, void *data,
 		break;
 	case VIRTGPU_PARAM_ALLOW_P2P:
 		value = vgdev->has_allow_p2p ? 1 : 0;
+		value = (value & 0xffff) | ((vgdev->output_cap_mask & 0xffff) << 16);
 		break;
 	default:
 		return -EINVAL;

--- a/drivers/gpu/drm/virtio/virtgpu_kms.c
+++ b/drivers/gpu/drm/virtio/virtgpu_kms.c
@@ -327,6 +327,12 @@ int virtio_gpu_init(struct virtio_device *vdev, struct drm_device *dev)
 	for(i=0; i<vgdev->num_vblankq; i++)
 		spin_lock_init(&vgdev->vblank[i].vblank.qlock);
 
+	if (vgdev->has_allow_p2p) {
+		virtio_cread_le(vgdev->vdev, struct virtio_gpu_config,
+                               output_bitmask, &vgdev->output_cap_mask);
+		DRM_INFO("p2p crtc bitmask 0x%x \r\n", vgdev->output_cap_mask);
+	}
+
 	ret = virtio_gpu_find_vqs(vgdev);
 	if (ret) {
 		DRM_ERROR("failed to find virt queues\n");

--- a/drivers/gpu/drm/virtio/virtgpu_vq.c
+++ b/drivers/gpu/drm/virtio/virtgpu_vq.c
@@ -1498,8 +1498,8 @@ void virtio_gpu_cmd_unmap(struct virtio_gpu_device *vgdev,
 	virtio_gpu_queue_ctrl_buffer(vgdev, vbuf);
 }
 
-void
-virtio_gpu_cmd_resource_create_blob(struct virtio_gpu_device *vgdev,
+static void
+virtio_gpu_cmd_resource_create_blob_internal(struct virtio_gpu_device *vgdev,
 				    struct virtio_gpu_object *bo,
 				    struct virtio_gpu_object_params *params,
 				    struct virtio_gpu_mem_entry *ents,
@@ -1525,6 +1525,18 @@ virtio_gpu_cmd_resource_create_blob(struct virtio_gpu_device *vgdev,
 
 	virtio_gpu_queue_ctrl_buffer(vgdev, vbuf);
 	bo->created = true;
+}
+
+void
+virtio_gpu_cmd_resource_create_blob(struct virtio_gpu_device *vgdev,
+				    struct virtio_gpu_object *bo,
+				    struct virtio_gpu_object_params *params,
+				    struct virtio_gpu_mem_entry *ents,
+				    uint32_t nents)
+{
+	if(bo->locate && vgdev->has_allow_p2p)
+		params->blob_flags |= VIRTGPU_BLOB_FLAG_USE_DEVICE_MEM;
+	virtio_gpu_cmd_resource_create_blob_internal(vgdev, bo, params, ents, nents);
 }
 
 void virtio_gpu_cmd_set_scanout_blob(struct virtio_gpu_device *vgdev,

--- a/include/uapi/drm/virtgpu_drm.h
+++ b/include/uapi/drm/virtgpu_drm.h
@@ -166,6 +166,7 @@ struct drm_virtgpu_resource_create_blob {
 #define VIRTGPU_BLOB_FLAG_USE_MAPPABLE     0x0001
 #define VIRTGPU_BLOB_FLAG_USE_SHAREABLE    0x0002
 #define VIRTGPU_BLOB_FLAG_USE_CROSS_DEVICE 0x0004
+#define VIRTGPU_BLOB_FLAG_USE_DEVICE_MEM      0x0008
 	/* zero is invalid blob_mem */
 	__u32 blob_mem;
 	__u32 blob_flags;

--- a/include/uapi/linux/virtio_gpu.h
+++ b/include/uapi/linux/virtio_gpu.h
@@ -489,6 +489,7 @@ struct virtio_gpu_config {
 	__le32 num_scanouts;
 	__le32 num_capsets;
 	__le32 num_pipe;
+	__le32 output_bitmask;
 };
 
 /* simple formats for fbcon/X use */


### PR DESCRIPTION
get config bitmask for crtc VF LMEM config and expose to user space by get param ioctl, compare the dma buf name for p2p specificly and notify backend.

Tracked-On: OAM-129106
Signed-off-by: hangliu1 <hang1.liu@intel.com>