### PR TITLE
DRM: Add the first atomic commit time for resume

### DIFF
--- a/drivers/acpi/sleep.c
+++ b/drivers/acpi/sleep.c
@@ -32,6 +32,7 @@
  */
 bool acpi_no_s5;
 static u8 sleep_states[ACPI_S_STATE_COUNT];
+ktime_t acpi_resume_begin;
 
 static void acpi_sleep_tts_switch(u32 acpi_state)
 {
@@ -598,6 +599,7 @@ static int acpi_suspend_enter(suspend_state_t pm_state)
 		if (error)
 			return error;
 		pr_info("Low-level resume complete\n");
+		acpi_resume_begin = ktime_get();
 		pm_set_resume_via_firmware();
 		break;
 	}

--- a/include/drm/drm_atomic.h
+++ b/include/drm/drm_atomic.h
@@ -428,6 +428,14 @@ struct drm_atomic_state {
 	 * commit without blocking.
 	 */
 	struct work_struct commit_work;
+
+	/**
+	 * @resume:
+	 *
+	 * Indicate if system just resume from S3, will used it to control if print
+	 * the first commit period.
+	 */
+	bool resume : 1;
 };
 
 void __drm_crtc_commit_free(struct kref *kref);

--- a/include/linux/suspend.h
+++ b/include/linux/suspend.h
@@ -11,6 +11,7 @@
 #include <linux/android_kabi.h>
 #include <asm/errno.h>
 
+extern ktime_t acpi_resume_begin;
 #ifdef CONFIG_VT
 extern void pm_set_vt_switch(int);
 #else


### PR DESCRIPTION
Print the period from S3 resume to firstly display commit

Tracked-On: OAM-128887