### PR TITLE
drm/virtio: Ensure lmem objects are used for dGPU backing CRTC

### DIFF
--- a/drivers/dma-buf/dma-buf.c
+++ b/drivers/dma-buf/dma-buf.c
@@ -978,8 +978,9 @@ EXPORT_SYMBOL_NS_GPL(dma_buf_dynamic_attach, DMA_BUF);
  */
 struct dma_buf_attachment *
 ____dma_buf_dynamic_attach(struct dma_buf *dmabuf, struct device *dev,
-			const struct dma_buf_attach_ops *importer_ops,
-			void *importer_priv, bool p2p)
+			   unsigned importer_type_id, unsigned flags,
+			   const struct dma_buf_attach_ops *importer_ops,
+			   void *importer_priv, bool p2p)
 {
 	struct dma_buf_attachment *attach;
 	int ret;
@@ -995,6 +996,8 @@ ____dma_buf_dynamic_attach(struct dma_buf *dmabuf, struct device *dev,
 		return ERR_PTR(-ENOMEM);
 
 	attach->dev = dev;
+	attach->importer_type_id = importer_type_id;
+	attach->flags = flags;
 	attach->dmabuf = dmabuf;
 	if (importer_ops)
 		attach->peer2peer = importer_ops->allow_peer2peer;

--- a/drivers/gpu/drm/virtio/virtgpu_object.c
+++ b/drivers/gpu/drm/virtio/virtgpu_object.c
@@ -23,6 +23,7 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <linux/dma-buf.h>
 #include <linux/dma-mapping.h>
 #include <linux/moduleparam.h>
 

--- a/drivers/gpu/drm/virtio/virtgpu_plane.c
+++ b/drivers/gpu/drm/virtio/virtgpu_plane.c
@@ -23,6 +23,8 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <linux/dma-buf.h>
+
 #include <drm/drm_atomic_helper.h>
 #include <drm/drm_damage_helper.h>
 #include <drm/drm_fourcc.h>
@@ -264,6 +266,26 @@ static int virtio_gpu_plane_atomic_check(struct drm_plane *plane,
 	if (IS_ERR(crtc_state))
                 return PTR_ERR(crtc_state);
 
+	/* Ensure lmem objects from i915_ag are attached to dGPU backing CRTC */
+	if (vgdev->output_cap_mask & (1lu << drm_crtc_index(new_plane_state->crtc))) {
+		for (int i = 0; i < DRM_FORMAT_MAX_PLANES; ++i) {
+			struct drm_gem_object *obj = new_plane_state->fb->obj[i];
+			if (!obj)
+				break;
+
+			if (!obj->import_attach)
+				return -EINVAL;
+
+			if (!(obj->import_attach->flags & DMABUF_ATTACH_FLAG_LMEM)) {
+				drm_dbg(vgdev->ddev, "cannot use non-i915_ag "
+					"buffer for crtc %u, driver name %s\n",
+					drm_crtc_index(new_plane_state->crtc),
+					obj->dev->driver->name);
+				return -EINVAL;
+			}
+		}
+	}
+
 	if(vgdev->has_scaling && (new_plane_state->fb->format->format != DRM_FORMAT_C8)) {
 		min_scale = 1;
 		max_scale = 0x30000-1;
@@ -322,7 +344,6 @@ static void virtio_gpu_resource_flush(struct drm_plane *plane,
 	struct virtio_gpu_object *bo;
 	struct virtio_gpu_object_array *objs = NULL;
 	struct virtio_gpu_fence *fence = NULL;
-	int i;
 
 	vgfb = to_virtio_gpu_framebuffer(plane->state->fb);
 	bo = gem_to_virtio_gpu_obj(vgfb->base.obj[0]);

--- a/drivers/gpu/drm/virtio/virtgpu_prime.c
+++ b/drivers/gpu/drm/virtio/virtgpu_prime.c
@@ -180,8 +180,9 @@ struct drm_gem_object *virtgpu_gem_prime_import(struct drm_device *dev,
 	}
 	spin_unlock(&dma_buf->name_lock);
 
-	attach = ____dma_buf_dynamic_attach(dma_buf, attach_dev, NULL, NULL,
-					    p2p);
+	attach = ____dma_buf_dynamic_attach(dma_buf, attach_dev,
+					    DMA_BUF_DRIVER_TYPE_ID_VIRTIO_GPU,
+					    0, NULL, NULL, p2p);
 	if (IS_ERR(attach))
 		return ERR_CAST(attach);
 

--- a/include/linux/dma-buf.h
+++ b/include/linux/dma-buf.h
@@ -535,6 +535,12 @@ struct dma_buf {
 	ANDROID_KABI_RESERVE(2);
 };
 
+#define DMA_BUF_DRIVER_TYPE_ID_GENERAL				0
+#define DMA_BUF_DRIVER_TYPE_ID_VIRTIO_GPU			2
+
+/* Set by exporter as an indicator that the buffer reiside in local memory. */
+#define DMABUF_ATTACH_FLAG_LMEM				(1lu << 0)
+
 /**
  * struct dma_buf_attach_ops - importer operations for an attachment
  *
@@ -585,6 +591,9 @@ struct dma_buf_attach_ops {
  * @importer_priv: importer specific attachment data.
  * @dma_map_attrs: DMA attributes to be used when the exporter maps the buffer
  * through dma_buf_map_attachment.
+ * @importer_type_id: used by exporter for identifying the importer
+ * @flags: shared by both exporter and importer for negotiation on the
+ * DMA mapping requirements.
  *
  * This structure holds the attachment information between the dma_buf buffer
  * and its user device(s). The list contains one attachment struct per device
@@ -609,6 +618,8 @@ struct dma_buf_attachment {
 
 	ANDROID_KABI_RESERVE(1);
 	ANDROID_KABI_RESERVE(2);
+	unsigned importer_type_id;
+	unsigned flags;
 };
 
 /**
@@ -620,6 +631,7 @@ struct dma_buf_attachment {
  * @flags:	mode flags for the file
  * @resv:	reservation-object, NULL to allocate default one
  * @priv:	Attach private data of allocator to this buffer
+ * @exporter_type:id: globally unique id for the exporter driver
  *
  * This structure holds the information required to export the buffer. Used
  * with dma_buf_export() only.
@@ -700,6 +712,7 @@ dma_buf_dynamic_attach(struct dma_buf *dmabuf, struct device *dev,
 		       void *importer_priv);
 struct dma_buf_attachment *
 ____dma_buf_dynamic_attach(struct dma_buf *dmabuf, struct device *dev,
+			   unsigned importer_type_id, unsigned flags,
 		           const struct dma_buf_attach_ops *importer_ops,
 		           void *importer_priv, bool p2p);
 void dma_buf_detach(struct dma_buf *dmabuf,


### PR DESCRIPTION
Use atomic check hook to ensure the framebuffers we are going to set satisfy the requirement for dGPU.