### PR TITLE
ACRN: implementation of monitor-less mwait

### DIFF
--- a/arch/x86/include/asm/mwait.h
+++ b/arch/x86/include/asm/mwait.h
@@ -7,6 +7,7 @@
 
 #include <asm/cpufeature.h>
 #include <asm/nospec-branch.h>
+#include <asm/hypervisor.h>
 
 #define MWAIT_SUBSTATE_MASK		0xf
 #define MWAIT_CSTATE_MASK		0xf
@@ -18,6 +19,7 @@
 #define CPUID_MWAIT_LEAF		5
 #define CPUID5_ECX_EXTENSIONS_SUPPORTED 0x1
 #define CPUID5_ECX_INTERRUPT_BREAK	0x2
+#define CPUID5_ECX_MONITOR_LESS 0x4
 
 #define MWAIT_ECX_INTERRUPT_BREAK	0x1
 #define MWAITX_ECX_TIMER_ENABLE		BIT(1)
@@ -107,16 +109,25 @@ static inline void __sti_mwait(unsigned long eax, unsigned long ecx)
  */
 static inline void mwait_idle_with_hints(unsigned long eax, unsigned long ecx)
 {
+	bool has_monitor_less_mwait;
+
 	if (static_cpu_has_bug(X86_BUG_MONITOR) || !current_set_polling_and_test()) {
 		if (static_cpu_has_bug(X86_BUG_CLFLUSH_MONITOR)) {
 			mb();
 			clflush((void *)&current_thread_info()->flags);
 			mb();
 		}
-
+		has_monitor_less_mwait = ((cpuid_ecx(CPUID_MWAIT_LEAF) & CPUID5_ECX_MONITOR_LESS) != 0);
+		/* CPUID may cause vmexit, which we do not wish to see between monitor/mwait. */
+		mb();
 		__monitor((void *)&current_thread_info()->flags, 0, 0);
-		if (!need_resched())
+		if (!need_resched()) {
+			if (!hypervisor_is_type(X86_HYPER_NATIVE) && has_monitor_less_mwait) {
+				current_clr_polling();
+				ecx |= 0x4;
+			}
 			__mwait(eax, ecx);
+		}
 	}
 	current_clr_polling();
 }


### PR DESCRIPTION
Monitor-less mwait is an extended x86 instruction feature that enables mwait be called without MONITOR pairing.

With the monitor-less mwait implementation, monitor is no longer required before calling mwait. And kernel wakes up from Cx idle state by interrupts, instead of mem write on the monitored address (which is hard for hypervisor to emulate).

The implementation includes:
1. Hypervisor will emulate CPUID.05H.ECX[2] to indicate the presence of monitor-less mwait.
2. Kernel marks ecx bit2 for MWAIT instruction to indicate it is calling a monitor-less mwait.
3. Kernel clears TIF_POLLING_NRFLAG before monitor-less mwait so that the idle core is going to be waked up by interrupts.