### PR TITLE
init/main.c: Print tsc when starting kernel and init process

### DIFF
--- a/init/main.c
+++ b/init/main.c
@@ -936,6 +936,7 @@ static void __init print_unknown_bootoptions(void)
 
 asmlinkage __visible void __init __no_sanitize_address start_kernel(void)
 {
+	pr_notice("%s, tsc: %llu\n", __func__, rdtsc());
 	char *command_line;
 	char *after_dashes;
 
@@ -1418,7 +1419,7 @@ static int run_init_process(const char *init_filename)
 	const char *const *p;
 
 	argv_init[0] = init_filename;
-	pr_info("Run %s as init process\n", init_filename);
+	pr_info("Run %s as init process, tsc: %llu\n", init_filename, rdtsc());
 	pr_debug("  with arguments:\n");
 	for (p = argv_init; *p; p++)
 		pr_debug("    %s\n", *p);


### PR DESCRIPTION
Print tsc when starting kernel and init process to help measure android cold boot accurately.

Tracked-On: OAM-130207