### PR TITLE
drm/virtio: wait for pageflip event for atomic disable

### DIFF
--- a/drivers/gpu/drm/virtio/virtgpu_drv.h
+++ b/drivers/gpu/drm/virtio/virtgpu_drv.h
@@ -239,6 +239,8 @@ struct virtio_gpu_drv_cap_cache {
 struct virtio_gpu_vblank {
 	struct virtio_gpu_queue vblank;
 	uint32_t buf[4];
+	struct completion notify;
+	bool first_vblank;
 };
 
 static inline bool drm_vblank_passed(u64 seq, u64 ref)

--- a/drivers/gpu/drm/virtio/virtgpu_vq.c
+++ b/drivers/gpu/drm/virtio/virtgpu_vq.c
@@ -122,6 +122,11 @@ void virtio_gpu_vblank_ack(struct virtqueue *vq)
 	if (!vgdev->has_flip_sequence)
 		return;
 
+	if (&vgdev->vblank[target].first_commit) {
+		complete(&vgdev->vblank[target].notify);
+		vgdev->vblank[target].first_commit = false;
+	}
+
 	struct drm_pending_vblank_event *e = xchg(&vgdev->cache_event[target], NULL);
 	if (!e)
 		return;


### PR DESCRIPTION
make sure virtio gpu receive page flip event when doing atomic disable.

Tracked-On: OAM-130135