### PR TITLE
display fix crash in intel_dp_aux_xfer

### DIFF
--- a/drivers/gpu/drm/i915/display/intel_dp_aux.c
+++ b/drivers/gpu/drm/i915/display/intel_dp_aux.c
@@ -233,6 +233,10 @@ intel_dp_aux_xfer(struct intel_dp *intel_dp,
 		ch_data[i] = intel_dp->aux_ch_data_reg(intel_dp, i);
 
 	if (is_tc_port) {
+		if (!dig_port) {
+			ret = -ENXIO;
+			goto out_fail;
+		}
 		intel_tc_port_lock(dig_port);
 		/*
 		 * Abort transfers on a disconnected port as required by
@@ -413,6 +417,7 @@ out_unlock:
 	if (is_tc_port)
 		intel_tc_port_unlock(dig_port);
 
+out_fail:
 	return ret;
 }
 


### PR DESCRIPTION
rdi is 0x00
[21:59:12.977211]: [  110.603521]  ? __intel_tc_port_lock+0xd/0x100
 [21:59:12.977320]: [  110.603748]  intel_dp_aux_xfer+0xb3/0x600 
Code: 0f 1f 84 00 00 00 00 00 66 66 2e 0f 1f 84 00 00 00 00 00 66 2e 0f 1f 84 00 00 00 00 00 0f 1f 44 00 00 41 54 55 89 f5 31 f6 53 <48> 8b 07 48 89 fb 48 83 c7 10 4c 8b 20 e8 21 58 72 00 48 8d bb a8
 0  0f 1f 44 00 00                                   nop        dword ptr [rax + rax]
 5  41 54                                            push       r12
 7  55                                               push       rbp
 8  89 f5                                            mov        ebp, esi
 a  31 f6                                            xor        esi, esi
 c  53                                               push       rbx
 d  <48> 8b 07                                       mov        rax, qword ptr [rdi]
10  48 89 fb                                         mov        rbx, rdi
13  48 83 c7 10                                      add        rdi, 0x10
17  4c 8b 20                                         mov        r12, qword ptr [rax]
1a  e8 21 58 72 00                                   call       0x725840

Tracked-On: IASW-1567